### PR TITLE
Implement starknet foundry integration tests along with EIP7496

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Starknet
+target
+Scarb.lock
+
+# Starknet foundry
+.snfoundry_cache

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# cairo-erc-7496
-NFT Dynamic Traits
+<div align="center">
+  <h1 align="center">ERC-7496 Dynamic Traits</h1>
+  <p align="center">
+    <a href="https://discord.gg/qqkBpmRDFE">
+        <img src="https://img.shields.io/badge/Discord-6666FF?style=for-the-badge&logo=discord&logoColor=white">
+    </a>
+    <a href="https://twitter.com/intent/follow?screen_name=Carbonable_io">
+        <img src="https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white">
+    </a>       
+  </p>
+  <h3 align="center">Dynamic Traits Contracts written in Cairo for Starknet.</h3>
+</div>
+
+### About
+
+A Cairo implementation of [EIP-7496](https://eips.ethereum.org/EIPS/eip-7496) based on the [Solidity Reference Implementation](https://github.com/ethereum/ERCs/tree/master/assets/erc-7496). EIP-7496 is an Ethereum standard for Dynamic Traits.
+
+> ## ⚠️ WARNING! ⚠️
+>
+> This is repo contains highly experimental code.
+> Expect rapid iteration.
+> **Use at your own risk.**
+
+### Project setup
+
+#### 📦 Requirements
+
+- [scarb](https://docs.swmansion.com/scarb/)
+
+### ⛏️ Compile
+
+```bash
+scarb build
+```
+
+### 💄 Code style
+
+```bash
+scarb fmt
+```
+
+### 🌡️ Test
+
+```bash
+scarb test
+```
+
+## 📄 License
+
+This project is released under the MIT license.

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cairo_erc_7496"
+version = "2.0.0"
+
+[lib]
+
+[dependencies]
+starknet = ">=2.2.0"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.10.0" }
+
+[dev-dependencies]
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.20.1" }
+
+[scripts]
+test = "snforge test"
+
+[[target.starknet-contract]]
+sierra = true
+casm = true

--- a/src/erc7496/erc7496.cairo
+++ b/src/erc7496/erc7496.cairo
@@ -31,7 +31,7 @@ mod ERC7496Component {
     /// Emitted when a dynamic trait is updated.
     #[derive(Drop, PartialEq, starknet::Event)]
     struct TraitUpdated {
-        // #[key]
+        #[key]
         trait_key: felt252,
         token_id: u256,
         trait_value: felt252

--- a/src/erc7496/erc7496.cairo
+++ b/src/erc7496/erc7496.cairo
@@ -1,0 +1,156 @@
+// @title DynamicTraits
+
+// @dev Implementation of [ERC-7496](https://eips.ethereum.org/EIPS/eip-7496) Dynamic Traits.
+
+// Requirements:
+// - Overwrite `setTrait` with access role restriction.
+// - Expose a function for `setTraitMetadataURI` with access role restriction if desired.
+#[starknet::component]
+mod ERC7496Component {
+    use openzeppelin::introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
+    use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
+    use openzeppelin::introspection::src5::SRC5Component::SRC5;
+    use openzeppelin::introspection::src5::SRC5Component;
+    use cairo_erc_7496::erc7496::interface;
+
+    #[storage]
+    struct Storage {
+        /// @dev A mapping of token ID to a mapping of trait key to trait value.
+        ERC7496_traits: LegacyMap<(u256, felt252), felt252>,
+        /// @dev An offchain string URI that points to a JSON file containing trait metadata.
+        ERC7498_trait_metadata_uri: ByteArray,
+    }
+
+    #[event]
+    #[derive(Drop, PartialEq, starknet::Event)]
+    enum Event {
+        TraitUpdated: TraitUpdated,
+        TraitMetadataURIUpdated: TraitMetadataURIUpdated
+    }
+
+    /// Emitted when a dynamic trait is updated.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct TraitUpdated {
+        // #[key]
+        trait_key: felt252,
+        token_id: u256,
+        trait_value: felt252
+    }
+
+    /// Emitted when metadata uri is updated.
+    #[derive(Drop, PartialEq, starknet::Event)]
+    struct TraitMetadataURIUpdated {}
+
+    mod Errors {
+        const TRAIT_VALUE_UNCHANGED: felt252 = 'ERC7496: trait value unchanged';
+    }
+
+    //
+    // External
+    //
+
+    #[embeddable_as(ERC7496Impl)]
+    impl ERC7496<
+        TContractState,
+        +HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>
+    > of interface::IERC7496<ComponentState<TContractState>> {
+        // @notice Get the URI for the trait metadata
+        fn get_trait_metadata_uri(self: @ComponentState<TContractState>) -> ByteArray {
+            // Return the trait metadata URI.
+            self.ERC7498_trait_metadata_uri.read()
+        }
+    }
+
+    //
+    // Internal
+    //
+
+    #[generate_trait]
+    impl InternalImpl<
+        TContractState,
+        +HasComponent<TContractState>,
+        impl SRC5: SRC5Component::HasComponent<TContractState>,
+        +Drop<TContractState>
+    > of InternalTrait<TContractState> {
+        /// Initializes the contract
+        /// This should only be used inside the contract's constructor.
+        fn initializer(ref self: ComponentState<TContractState>) {
+            let mut src5_component = get_dep_component_mut!(ref self, SRC5);
+            src5_component.register_interface(interface::IERC7496_ID);
+        }
+
+        // @notice Get the value of a trait for a given token ID.
+        // @param tokenId The token ID to get the trait value for
+        // @param traitKey The trait key to get the value of
+        fn _get_trait_value(
+            self: @ComponentState<TContractState>, token_id: u256, trait_key: felt252
+        ) -> felt252 {
+            // Return the trait value.
+            self.ERC7496_traits.read((token_id, trait_key))
+        }
+
+        // @notice Get the values of traits for a given token ID.
+        // @param tokenId The token ID to get the trait values for
+        // @param traitKeys The trait keys to get the values of
+        fn _get_trait_values(
+            self: @ComponentState<TContractState>, token_id: u256, trait_keys: Span<felt252>
+        ) -> Span<felt252> {
+            let mut trait_values = array![];
+            // Assign each trait value to the corresponding key.
+            let mut index = 0;
+            while index < trait_keys
+                .len() {
+                    trait_values
+                        .append(self.ERC7496_traits.read((token_id, *trait_keys.at(index))));
+                    index += 1;
+                };
+            trait_values.span()
+        }
+
+        // @notice Set the value of a trait for a given token ID.
+        //         Reverts if the trait value is unchanged.
+        // @dev    IMPORTANT: Override this method with access role restriction.
+        // @param tokenId The token ID to set the trait value for
+        // @param traitKey The trait key to set the value of
+        // @param newValue The new trait value to set
+        fn _set_trait(
+            ref self: ComponentState<TContractState>,
+            token_id: u256,
+            trait_key: felt252,
+            new_value: felt252
+        ) {
+            // Revert if the new value is the same as the existing value.
+            let existing_value = self.ERC7496_traits.read((token_id, trait_key));
+            assert(existing_value != new_value, Errors::TRAIT_VALUE_UNCHANGED);
+            // Set the new trait value.
+            self._set_trait_internal(token_id, trait_key, new_value);
+            // Emit the event noting the update.
+            self.emit(TraitUpdated { trait_key, token_id, trait_value: new_value });
+        }
+
+        // @notice Set the trait value (without emitting an event).
+        // @param tokenId The token ID to set the trait value for
+        // @param traitKey The trait key to set the value of
+        // @param newValue The new trait value to set
+        fn _set_trait_internal(
+            ref self: ComponentState<TContractState>,
+            token_id: u256,
+            trait_key: felt252,
+            new_value: felt252
+        ) {
+            // Set the new trait value.
+            self.ERC7496_traits.write((token_id, trait_key), new_value);
+        }
+
+        // @notice Set the URI for the trait metadata.
+        // @param uri The new URI to set.
+        fn _set_trait_metadata_uri(ref self: ComponentState<TContractState>, uri: ByteArray) {
+            // Set the new trait metadata URI.
+            self.ERC7498_trait_metadata_uri.write(uri);
+            // Emit the event noting the update.
+            self.emit(TraitMetadataURIUpdated {});
+        }
+    }
+}

--- a/src/erc7496/erc7496.cairo
+++ b/src/erc7496/erc7496.cairo
@@ -7,11 +7,10 @@
 // - Expose a function for `setTraitMetadataURI` with access role restriction if desired.
 #[starknet::component]
 mod ERC7496Component {
-    use openzeppelin::introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component::InternalTrait as SRC5InternalTrait;
     use openzeppelin::introspection::src5::SRC5Component::SRC5;
     use openzeppelin::introspection::src5::SRC5Component;
-    use cairo_erc_7496::erc7496::interface;
+    use cairo_erc_7496::erc7496::interface::{IERC7496_ID, IERC7496};
 
     #[storage]
     struct Storage {
@@ -55,7 +54,7 @@ mod ERC7496Component {
         +HasComponent<TContractState>,
         +SRC5Component::HasComponent<TContractState>,
         +Drop<TContractState>
-    > of interface::IERC7496<ComponentState<TContractState>> {
+    > of IERC7496<ComponentState<TContractState>> {
         // @notice Get the URI for the trait metadata
         fn get_trait_metadata_uri(self: @ComponentState<TContractState>) -> ByteArray {
             // Return the trait metadata URI.
@@ -78,7 +77,7 @@ mod ERC7496Component {
         /// This should only be used inside the contract's constructor.
         fn initializer(ref self: ComponentState<TContractState>) {
             let mut src5_component = get_dep_component_mut!(ref self, SRC5);
-            src5_component.register_interface(interface::IERC7496_ID);
+            src5_component.register_interface(IERC7496_ID);
         }
 
         // @notice Get the value of a trait for a given token ID.

--- a/src/erc7496/interface.cairo
+++ b/src/erc7496/interface.cairo
@@ -5,5 +5,5 @@ trait IERC7496<TState> {
     // fn get_trait_value(self: @TState, token_id: u256, trait_key: felt252) -> felt252;
     // fn get_trait_values(self: @TState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252>;
     fn get_trait_metadata_uri(self: @TState) -> ByteArray;
-    // fn set_trait(ref self: TState, token_id: u256, trait_key: felt252, new_value: felt252);
+// fn set_trait(ref self: TState, token_id: u256, trait_key: felt252, new_value: felt252);
 }

--- a/src/erc7496/interface.cairo
+++ b/src/erc7496/interface.cairo
@@ -1,0 +1,9 @@
+const IERC7496_ID: felt252 = 0xaf332f3e;
+
+#[starknet::interface]
+trait IERC7496<TState> {
+    // fn get_trait_value(self: @TState, token_id: u256, trait_key: felt252) -> felt252;
+    // fn get_trait_values(self: @TState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252>;
+    fn get_trait_metadata_uri(self: @TState) -> ByteArray;
+    // fn set_trait(ref self: TState, token_id: u256, trait_key: felt252, new_value: felt252);
+}

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,0 +1,9 @@
+mod erc7496 {
+    mod interface;
+    mod erc7496;
+}
+
+mod presets {
+    mod erc721_dynamic_traits;
+}
+

--- a/src/presets/erc721_dynamic_traits.cairo
+++ b/src/presets/erc721_dynamic_traits.cairo
@@ -67,7 +67,7 @@ mod ERC721DynamicTraits {
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
-    // ERC721Mixin
+    // ERC721
     #[abi(embed_v0)]
     impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
@@ -115,6 +115,7 @@ mod ERC721DynamicTraits {
     #[abi(embed_v0)]
     impl ERC721DynamicTraitsImpl of super::IERC721DynamicTraits<ContractState> {
         fn mint(ref self: ContractState, to: ContractAddress, token_id: u256) {
+            self.ownable.assert_only_owner();
             self.erc721._mint(to, token_id);
         }
 

--- a/src/presets/erc721_dynamic_traits.cairo
+++ b/src/presets/erc721_dynamic_traits.cairo
@@ -104,10 +104,8 @@ mod ERC721DynamicTraits {
 
     /// Sets the token `name`, `symbol` and `base_uri`.
     #[constructor]
-    fn constructor(ref self: ContractState,
-    name: ByteArray,
-    symbol: ByteArray,
-    base_uri: ByteArray,
+    fn constructor(
+        ref self: ContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray,
     ) {
         self.ownable.initializer(get_caller_address());
         self.erc721.initializer(name, symbol, base_uri);
@@ -125,12 +123,16 @@ mod ERC721DynamicTraits {
             self.erc7496._get_trait_value(token_id, trait_key)
         }
 
-        fn get_trait_values(self: @ContractState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252> {
+        fn get_trait_values(
+            self: @ContractState, token_id: u256, trait_keys: Span<felt252>
+        ) -> Span<felt252> {
             assert(self.erc721._exists(token_id), ERC721Component::Errors::INVALID_TOKEN_ID);
             self.erc7496._get_trait_values(token_id, trait_keys)
         }
 
-        fn set_trait(ref self: ContractState, token_id: u256, trait_key: felt252, new_value: felt252) {
+        fn set_trait(
+            ref self: ContractState, token_id: u256, trait_key: felt252, new_value: felt252
+        ) {
             self.ownable.assert_only_owner();
             assert(self.erc721._exists(token_id), ERC721Component::Errors::INVALID_TOKEN_ID);
             self.erc7496._set_trait(token_id, trait_key, new_value);

--- a/src/presets/erc721_dynamic_traits.cairo
+++ b/src/presets/erc721_dynamic_traits.cairo
@@ -1,0 +1,144 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IERC721DynamicTraits<TState> {
+    fn mint(ref self: TState, to: ContractAddress, token_id: u256);
+    fn get_trait_value(self: @TState, token_id: u256, trait_key: felt252) -> felt252;
+    fn get_trait_values(self: @TState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252>;
+    fn set_trait(ref self: TState, token_id: u256, trait_key: felt252, new_value: felt252);
+    fn set_trait_metadata_uri(ref self: TState, uri: ByteArray);
+}
+
+#[starknet::interface]
+trait IERC721DynamicTraitsMixin<TState> {
+    // IERC721DynamicTraits
+    fn mint(ref self: TState, to: ContractAddress, token_id: u256);
+    // IERC7496
+    fn get_trait_value(self: @TState, token_id: u256, trait_key: felt252) -> felt252;
+    fn get_trait_values(self: @TState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252>;
+    fn get_trait_metadata_uri(self: @TState) -> ByteArray;
+    fn set_trait(ref self: TState, token_id: u256, trait_key: felt252, new_value: felt252);
+    fn set_trait_metadata_uri(ref self: TState, uri: ByteArray);
+    // IERC721
+    fn balance_of(self: @TState, account: ContractAddress) -> u256;
+    fn owner_of(self: @TState, token_id: u256) -> ContractAddress;
+    fn safe_transfer_from(
+        ref self: TState,
+        from: ContractAddress,
+        to: ContractAddress,
+        token_id: u256,
+        data: Span<felt252>
+    );
+    fn transfer_from(ref self: TState, from: ContractAddress, to: ContractAddress, token_id: u256);
+    fn approve(ref self: TState, to: ContractAddress, token_id: u256);
+    fn set_approval_for_all(ref self: TState, operator: ContractAddress, approved: bool);
+    fn get_approved(self: @TState, token_id: u256) -> ContractAddress;
+    fn is_approved_for_all(
+        self: @TState, owner: ContractAddress, operator: ContractAddress
+    ) -> bool;
+    // Ownable
+    fn owner(self: @TState) -> ContractAddress;
+    fn transfer_ownership(ref self: TState, new_owner: ContractAddress);
+    fn renounce_ownership(ref self: TState);
+    // ISRC5
+    fn supports_interface(self: @TState, interface_id: felt252) -> bool;
+}
+
+#[starknet::contract]
+mod ERC721DynamicTraits {
+    use starknet::ContractAddress;
+    use starknet::get_caller_address;
+    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::token::erc721::ERC721Component;
+    use cairo_erc_7496::erc7496::erc7496::ERC7496Component;
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: ERC721Component, storage: erc721, event: ERC721Event);
+    component!(path: ERC7496Component, storage: erc7496, event: ERC7496Event);
+
+    // SRC5
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+
+    // Ownable
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+    // ERC721Mixin
+    #[abi(embed_v0)]
+    impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
+    impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
+
+    // ERC7496
+    #[abi(embed_v0)]
+    impl ERC7496Impl = ERC7496Component::ERC7496Impl<ContractState>;
+    impl ERC7496InternalImpl = ERC7496Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        #[substorage(v0)]
+        erc721: ERC721Component::Storage,
+        #[substorage(v0)]
+        erc7496: ERC7496Component::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+        #[flat]
+        ERC721Event: ERC721Component::Event,
+        #[flat]
+        ERC7496Event: ERC7496Component::Event,
+    }
+
+    /// Sets the token `name`, `symbol` and `base_uri`.
+    #[constructor]
+    fn constructor(ref self: ContractState,
+    name: ByteArray,
+    symbol: ByteArray,
+    base_uri: ByteArray,
+    ) {
+        self.ownable.initializer(get_caller_address());
+        self.erc721.initializer(name, symbol, base_uri);
+        self.erc7496.initializer();
+    }
+
+    #[abi(embed_v0)]
+    impl ERC721DynamicTraitsImpl of super::IERC721DynamicTraits<ContractState> {
+        fn mint(ref self: ContractState, to: ContractAddress, token_id: u256) {
+            self.erc721._mint(to, token_id);
+        }
+
+        fn get_trait_value(self: @ContractState, token_id: u256, trait_key: felt252) -> felt252 {
+            assert(self.erc721._exists(token_id), ERC721Component::Errors::INVALID_TOKEN_ID);
+            self.erc7496._get_trait_value(token_id, trait_key)
+        }
+
+        fn get_trait_values(self: @ContractState, token_id: u256, trait_keys: Span<felt252>) -> Span<felt252> {
+            assert(self.erc721._exists(token_id), ERC721Component::Errors::INVALID_TOKEN_ID);
+            self.erc7496._get_trait_values(token_id, trait_keys)
+        }
+
+        fn set_trait(ref self: ContractState, token_id: u256, trait_key: felt252, new_value: felt252) {
+            self.ownable.assert_only_owner();
+            assert(self.erc721._exists(token_id), ERC721Component::Errors::INVALID_TOKEN_ID);
+            self.erc7496._set_trait(token_id, trait_key, new_value);
+        }
+
+        fn set_trait_metadata_uri(ref self: ContractState, uri: ByteArray) {
+            self.ownable.assert_only_owner();
+            self.erc7496._set_trait_metadata_uri(uri);
+        }
+    }
+}

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -1,2 +1,3 @@
 #[cfg(test)]
+#[feature("safe_dispatcher")]
 mod test_erc7496;

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod test_erc7496;

--- a/tests/test_erc7496.cairo
+++ b/tests/test_erc7496.cairo
@@ -1,0 +1,179 @@
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+use snforge_std::{
+    declare,
+    ContractClassTrait,
+    start_prank,
+    CheatTarget,
+    spy_events,
+    SpyOn,
+    EventSpy,
+    EventAssertions
+};
+use openzeppelin::utils::serde::SerializedAppend;
+use cairo_erc_7496::erc7496::interface::IERC7496_ID;
+use cairo_erc_7496::presets::erc721_dynamic_traits::{
+    ERC721DynamicTraits,
+    IERC721DynamicTraitsMixinDispatcherTrait,
+    IERC721DynamicTraitsMixinDispatcher
+};
+
+fn NAME() -> ByteArray {
+    "ERC721DynamicTraits"
+}
+
+fn SYMBOL() -> ByteArray {
+    "ERC721DT"
+}
+
+fn BASE_URI() -> ByteArray {
+    "https://example.com"
+}
+
+fn RECIPIENT() -> ContractAddress {
+    contract_address_const::<'RECIPIENT'>()
+}
+
+fn OTHER() -> ContractAddress {
+    contract_address_const::<'OTHER'>()
+}
+
+fn METADATA_URI() -> ByteArray {
+    "https://example.com/labels.json"
+}
+
+fn setup() -> (IERC721DynamicTraitsMixinDispatcher, ContractAddress) {
+    let contract = declare("ERC721DynamicTraits");
+    let mut calldata: Array<felt252> = array![];
+    calldata.append_serde(NAME());
+    calldata.append_serde(SYMBOL());
+    calldata.append_serde(BASE_URI());
+    let contract_address = contract.deploy(@calldata).unwrap();
+    let token = IERC721DynamicTraitsMixinDispatcher { contract_address };
+    (token, contract_address)
+}
+
+#[test]
+fn test_supports_interface_id() {
+    let (token, _contract_address) = setup();
+    assert!(token.supports_interface(IERC7496_ID));
+}
+
+#[test]
+fn test_returns_value_set() {
+    let (token, contract_address) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+    let key = 'testKey';
+    let value = 'foo';
+    let token_id = 12345;
+    token.mint(RECIPIENT(), token_id);
+    token.set_trait(token_id, key, value);
+    spy.assert_emitted(@array![
+        (
+            contract_address,
+            ERC721DynamicTraits::ERC7496Component::Event::TraitUpdated(
+                ERC721DynamicTraits::ERC7496Component::TraitUpdated {
+                    trait_key: key,
+                    token_id,
+                    trait_value: value
+                }
+            )
+        )
+    ]);
+    assert_eq!(token.get_trait_value(token_id, key), value);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_only_owner_can_set_values() {
+    let (token, contract_address) = setup();
+    start_prank(CheatTarget::One(contract_address), OTHER());
+    token.set_trait(0, 'test', 'test');
+}
+
+#[test]
+#[should_panic(expected: 'ERC7496: trait value unchanged')]
+fn test_set_trait_unchanged() {
+    let (token, _contract_address) = setup();
+    let key = 'testKey';
+    let value = 'foo';
+    let token_id = 1;
+    token.mint(RECIPIENT(), token_id);
+    token.set_trait(token_id, key, value);
+    token.set_trait(token_id, key, value);
+}
+
+#[test]
+fn test_get_trait_values() {
+    let (token, _contract_address) = setup();
+    let key1 = 'testKeyOne';
+    let key2 = 'testKeyTwo';
+    let value1 = 'foo';
+    let value2 = 'bar';
+    let token_id = 1;
+    token.mint(RECIPIENT(), token_id);
+    token.set_trait(token_id, key1, value1);
+    token.set_trait(token_id, key2, value2);
+    let values = token.get_trait_values(token_id, array![key1, key2].span());
+    assert_eq!(*values.at(0), value1);
+    assert_eq!(*values.at(1), value2);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_get_and_set_trait_metadata_uri() {
+    let (token, contract_address) = setup();
+    let mut spy = spy_events(SpyOn::One(contract_address));
+    token.set_trait_metadata_uri(METADATA_URI());
+    spy.assert_emitted(@array![
+        (
+            contract_address,
+            ERC721DynamicTraits::ERC7496Component::Event::TraitMetadataURIUpdated(
+                ERC721DynamicTraits::ERC7496Component::TraitMetadataURIUpdated {}
+            )
+        )
+    ]);
+    assert_eq!(token.get_trait_metadata_uri(), METADATA_URI());
+    start_prank(CheatTarget::One(contract_address), OTHER());
+    token.set_trait_metadata_uri(METADATA_URI());
+}
+
+#[test]
+#[should_panic(expected: 'ERC721: invalid token ID')]
+fn test_set_trait_value_nonexistent_token() {
+    let (token, _contract_address) = setup();
+    let key = 'testKey';
+    let value = 1;
+    let token_id = 1;
+    token.set_trait(token_id, key, value);
+}
+
+#[test]
+#[should_panic(expected: 'ERC721: invalid token ID')]
+fn test_get_trait_value_nonexistent_token() {
+    let (token, _contract_address) = setup();
+    let key = 'testKey';
+    let token_id = 1;
+    token.get_trait_value(token_id, key);
+}
+
+#[test]
+#[should_panic(expected: 'ERC721: invalid token ID')]
+fn test_get_trait_values_nonexistent_token() {
+    let (token, _contract_address) = setup();
+    let key = 'testKey';
+    let token_id = 1;
+    token.get_trait_values(token_id, array![key].span());
+}
+
+#[test]
+fn test_get_trait_value_default_zero_value() {
+    let (token, _contract_address) = setup();
+    let key = 'testKey';
+    let token_id = 1;
+    token.mint(RECIPIENT(), token_id);
+    let value = token.get_trait_value(token_id, key);
+    assert_eq!(value, 0);
+    let values = token.get_trait_values(token_id, array![key].span());
+    assert_eq!(*values.at(0), 0);
+}

--- a/tests/test_erc7496.cairo
+++ b/tests/test_erc7496.cairo
@@ -1,20 +1,13 @@
 use starknet::ContractAddress;
 use starknet::contract_address_const;
 use snforge_std::{
-    declare,
-    ContractClassTrait,
-    start_prank,
-    CheatTarget,
-    spy_events,
-    SpyOn,
-    EventSpy,
+    declare, ContractClassTrait, start_prank, CheatTarget, spy_events, SpyOn, EventSpy,
     EventAssertions
 };
 use openzeppelin::utils::serde::SerializedAppend;
 use cairo_erc_7496::erc7496::interface::IERC7496_ID;
 use cairo_erc_7496::presets::erc721_dynamic_traits::{
-    ERC721DynamicTraits,
-    IERC721DynamicTraitsMixinDispatcherTrait,
+    ERC721DynamicTraits, IERC721DynamicTraitsMixinDispatcherTrait,
     IERC721DynamicTraitsMixinDispatcher
 };
 
@@ -68,18 +61,19 @@ fn test_returns_value_set() {
     let token_id = 12345;
     token.mint(RECIPIENT(), token_id);
     token.set_trait(token_id, key, value);
-    spy.assert_emitted(@array![
-        (
-            contract_address,
-            ERC721DynamicTraits::ERC7496Component::Event::TraitUpdated(
-                ERC721DynamicTraits::ERC7496Component::TraitUpdated {
-                    trait_key: key,
-                    token_id,
-                    trait_value: value
-                }
-            )
-        )
-    ]);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    ERC721DynamicTraits::ERC7496Component::Event::TraitUpdated(
+                        ERC721DynamicTraits::ERC7496Component::TraitUpdated {
+                            trait_key: key, token_id, trait_value: value
+                        }
+                    )
+                )
+            ]
+        );
     assert_eq!(token.get_trait_value(token_id, key), value);
 }
 
@@ -125,14 +119,17 @@ fn test_get_and_set_trait_metadata_uri() {
     let (token, contract_address) = setup();
     let mut spy = spy_events(SpyOn::One(contract_address));
     token.set_trait_metadata_uri(METADATA_URI());
-    spy.assert_emitted(@array![
-        (
-            contract_address,
-            ERC721DynamicTraits::ERC7496Component::Event::TraitMetadataURIUpdated(
-                ERC721DynamicTraits::ERC7496Component::TraitMetadataURIUpdated {}
-            )
-        )
-    ]);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    ERC721DynamicTraits::ERC7496Component::Event::TraitMetadataURIUpdated(
+                        ERC721DynamicTraits::ERC7496Component::TraitMetadataURIUpdated {}
+                    )
+                )
+            ]
+        );
     assert_eq!(token.get_trait_metadata_uri(), METADATA_URI());
     start_prank(CheatTarget::One(contract_address), OTHER());
     token.set_trait_metadata_uri(METADATA_URI());

--- a/tests/test_erc7496.cairo
+++ b/tests/test_erc7496.cairo
@@ -1,14 +1,18 @@
 use starknet::ContractAddress;
 use starknet::contract_address_const;
 use snforge_std::{
-    declare, ContractClassTrait, start_prank, CheatTarget, spy_events, SpyOn, EventSpy,
-    EventAssertions
+    declare, ContractClassTrait, test_address, start_prank, CheatTarget, spy_events, SpyOn,
+    EventSpy, EventAssertions
 };
 use openzeppelin::utils::serde::SerializedAppend;
+use openzeppelin::access::ownable::OwnableComponent;
+use openzeppelin::token::erc721::ERC721Component;
 use cairo_erc_7496::erc7496::interface::IERC7496_ID;
+use cairo_erc_7496::erc7496::erc7496::ERC7496Component;
 use cairo_erc_7496::presets::erc721_dynamic_traits::{
     ERC721DynamicTraits, IERC721DynamicTraitsMixinDispatcherTrait,
-    IERC721DynamicTraitsMixinDispatcher
+    IERC721DynamicTraitsMixinDispatcher, IERC721DynamicTraitsMixinSafeDispatcherTrait,
+    IERC721DynamicTraitsMixinSafeDispatcher
 };
 
 fn NAME() -> ByteArray {
@@ -23,10 +27,6 @@ fn BASE_URI() -> ByteArray {
     "https://example.com"
 }
 
-fn RECIPIENT() -> ContractAddress {
-    contract_address_const::<'RECIPIENT'>()
-}
-
 fn OTHER() -> ContractAddress {
     contract_address_const::<'OTHER'>()
 }
@@ -35,7 +35,9 @@ fn METADATA_URI() -> ByteArray {
     "https://example.com/labels.json"
 }
 
-fn setup() -> (IERC721DynamicTraitsMixinDispatcher, ContractAddress) {
+fn setup() -> (
+    ContractAddress, IERC721DynamicTraitsMixinDispatcher, IERC721DynamicTraitsMixinSafeDispatcher
+) {
     let contract = declare("ERC721DynamicTraits");
     let mut calldata: Array<felt252> = array![];
     calldata.append_serde(NAME());
@@ -43,23 +45,24 @@ fn setup() -> (IERC721DynamicTraitsMixinDispatcher, ContractAddress) {
     calldata.append_serde(BASE_URI());
     let contract_address = contract.deploy(@calldata).unwrap();
     let token = IERC721DynamicTraitsMixinDispatcher { contract_address };
-    (token, contract_address)
+    let token_safe = IERC721DynamicTraitsMixinSafeDispatcher { contract_address };
+    (contract_address, token, token_safe)
 }
 
 #[test]
 fn test_supports_interface_id() {
-    let (token, _contract_address) = setup();
+    let (_contract_address, token, _token_safe) = setup();
     assert!(token.supports_interface(IERC7496_ID));
 }
 
 #[test]
 fn test_returns_value_set() {
-    let (token, contract_address) = setup();
-    let mut spy = spy_events(SpyOn::One(contract_address));
+    let (contract_address, token, _token_safe) = setup();
     let key = 'testKey';
     let value = 'foo';
     let token_id = 12345;
-    token.mint(RECIPIENT(), token_id);
+    token.mint(test_address(), token_id);
+    let mut spy = spy_events(SpyOn::One(contract_address));
     token.set_trait(token_id, key, value);
     spy
         .assert_emitted(
@@ -78,34 +81,42 @@ fn test_returns_value_set() {
 }
 
 #[test]
-#[should_panic(expected: 'Caller is not the owner')]
 fn test_only_owner_can_set_values() {
-    let (token, contract_address) = setup();
+    let (contract_address, _token, token_safe) = setup();
     start_prank(CheatTarget::One(contract_address), OTHER());
-    token.set_trait(0, 'test', 'test');
+    match token_safe.set_trait(0, 'test', 'test') {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), OwnableComponent::Errors::NOT_OWNER);
+        }
+    }
 }
 
 #[test]
-#[should_panic(expected: 'ERC7496: trait value unchanged')]
 fn test_set_trait_unchanged() {
-    let (token, _contract_address) = setup();
+    let (_contract_address, token, token_safe) = setup();
     let key = 'testKey';
     let value = 'foo';
     let token_id = 1;
-    token.mint(RECIPIENT(), token_id);
+    token.mint(test_address(), token_id);
     token.set_trait(token_id, key, value);
-    token.set_trait(token_id, key, value);
+    match token_safe.set_trait(token_id, key, value) {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC7496Component::Errors::TRAIT_VALUE_UNCHANGED);
+        }
+    }
 }
 
 #[test]
 fn test_get_trait_values() {
-    let (token, _contract_address) = setup();
+    let (_contract_address, token, _token_safe) = setup();
     let key1 = 'testKeyOne';
     let key2 = 'testKeyTwo';
     let value1 = 'foo';
     let value2 = 'bar';
     let token_id = 1;
-    token.mint(RECIPIENT(), token_id);
+    token.mint(test_address(), token_id);
     token.set_trait(token_id, key1, value1);
     token.set_trait(token_id, key2, value2);
     let values = token.get_trait_values(token_id, array![key1, key2].span());
@@ -114,9 +125,8 @@ fn test_get_trait_values() {
 }
 
 #[test]
-#[should_panic(expected: 'Caller is not the owner')]
 fn test_get_and_set_trait_metadata_uri() {
-    let (token, contract_address) = setup();
+    let (contract_address, token, token_safe) = setup();
     let mut spy = spy_events(SpyOn::One(contract_address));
     token.set_trait_metadata_uri(METADATA_URI());
     spy
@@ -132,43 +142,46 @@ fn test_get_and_set_trait_metadata_uri() {
         );
     assert_eq!(token.get_trait_metadata_uri(), METADATA_URI());
     start_prank(CheatTarget::One(contract_address), OTHER());
-    token.set_trait_metadata_uri(METADATA_URI());
+    match token_safe.set_trait_metadata_uri(METADATA_URI()) {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), OwnableComponent::Errors::NOT_OWNER);
+        }
+    }
 }
 
 #[test]
-#[should_panic(expected: 'ERC721: invalid token ID')]
-fn test_set_trait_value_nonexistent_token() {
-    let (token, _contract_address) = setup();
+fn test_get_and_set_trait_value_nonexistent_token() {
+    let (_contract_address, _token, token_safe) = setup();
     let key = 'testKey';
     let value = 1;
     let token_id = 1;
-    token.set_trait(token_id, key, value);
-}
-
-#[test]
-#[should_panic(expected: 'ERC721: invalid token ID')]
-fn test_get_trait_value_nonexistent_token() {
-    let (token, _contract_address) = setup();
-    let key = 'testKey';
-    let token_id = 1;
-    token.get_trait_value(token_id, key);
-}
-
-#[test]
-#[should_panic(expected: 'ERC721: invalid token ID')]
-fn test_get_trait_values_nonexistent_token() {
-    let (token, _contract_address) = setup();
-    let key = 'testKey';
-    let token_id = 1;
-    token.get_trait_values(token_id, array![key].span());
+    match token_safe.set_trait(token_id, key, value) {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC721Component::Errors::INVALID_TOKEN_ID);
+        }
+    }
+    match token_safe.get_trait_value(token_id, key) {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC721Component::Errors::INVALID_TOKEN_ID);
+        }
+    }
+    match token_safe.get_trait_values(token_id, array![key].span()) {
+        Result::Ok(_) => panic_with_felt252('FAIL'),
+        Result::Err(panic_data) => {
+            assert_eq!(*panic_data.at(0), ERC721Component::Errors::INVALID_TOKEN_ID);
+        }
+    }
 }
 
 #[test]
 fn test_get_trait_value_default_zero_value() {
-    let (token, _contract_address) = setup();
+    let (_contract_address, token, _token_safe) = setup();
     let key = 'testKey';
     let token_id = 1;
-    token.mint(RECIPIENT(), token_id);
+    token.mint(test_address(), token_id);
     let value = token.get_trait_value(token_id, key);
     assert_eq!(value, 0);
     let values = token.get_trait_values(token_id, array![key].span());


### PR DESCRIPTION
This PR implements the starknet foundry integration tests replicated from the reference Solidity implementation.
I went along and implemented ERC7496 as a component to pass the tests accordingly.
I had an issue with the correct design pattern to implement overrides in Cairo.
If I add a method in the component interface eg. 'set_trait', I'm unable to override it in the preset, I'm getting the following error:

Failed to generate ABI: Duplicate entry point: 'set_trait'. This is not currently supported.

I ended up declaring the overrides as internal methods and declaring the proper interface on the preset instead but it doesn't feel quite right.

Fixes #3
Fixes #1